### PR TITLE
Handle exact aspect time with minute and second

### DIFF
--- a/backend/horary_engine/aspects.py
+++ b/backend/horary_engine/aspects.py
@@ -429,9 +429,11 @@ def calculate_enhanced_degrees_to_exact(
             try:
                 exact_jd = jd_ut + t
                 # Convert back to datetime
-                year, month, day, hour = swe.jdut1_to_utc(exact_jd, 1)  # Flag 1 for Gregorian
+                year, month, day, hour, minute, second = swe.jdut1_to_utc(
+                    exact_jd, 1
+                )  # Flag 1 for Gregorian
                 exact_time = datetime.datetime(
-                    int(year), int(month), int(day), int(hour), int((hour % 1) * 60)
+                    int(year), int(month), int(day), int(hour), int(minute), int(second)
                 )
             except Exception:
                 exact_time = None


### PR DESCRIPTION
## Summary
- Include minute and second when converting Julian date to UTC for exact aspect calculations
- Construct datetime with year, month, day, hour, minute and second components

## Testing
- `pytest -q`
- `python -m py_compile backend/horary_engine/aspects.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac04a0371c8324a477d8e5b24c3e57