### PR TITLE
Refine prohibition aspect validation

### DIFF
--- a/backend/horary_engine/perfection.py
+++ b/backend/horary_engine/perfection.py
@@ -60,23 +60,13 @@ def check_future_prohibitions(
     reception_calc = TraditionalReceptionCalculator()
 
     def _valid(t: float, p_a, p_b) -> bool:
-        if t is None or t >= days_ahead or t <= -days_ahead:
+        if t is None or t <= 0 or t >= days_ahead:
             return False
-        if not require_in_sign or allow_out_of_sign:
-            return True
-        if t >= 0:
+        if require_in_sign and not allow_out_of_sign:
             exit_a = days_to_sign_exit(p_a.longitude, p_a.speed)
             exit_b = days_to_sign_exit(p_b.longitude, p_b.speed)
-            return (
-                (exit_a is None or t < exit_a)
-                and (exit_b is None or t < exit_b)
-            )
-        entry_a = days_to_sign_exit(p_a.longitude, -p_a.speed)
-        entry_b = days_to_sign_exit(p_b.longitude, -p_b.speed)
-        return (
-            (entry_a is None or -t < entry_a)
-            and (entry_b is None or -t < entry_b)
-        )
+            return t < exit_a and t < exit_b
+        return True
 
     events: List[Dict[str, Any]] = []
 


### PR DESCRIPTION
## Summary
- Simplify `_valid` logic in `check_future_prohibitions`
- Ensure prohibitions only consider future aspects and optionally enforce in-sign requirement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac0a0c9e7c8324866d8e5f0e53784a