### PR TITLE
feat: add aspect verb helper for prohibitions

### DIFF
--- a/backend/horary_engine/perfection.py
+++ b/backend/horary_engine/perfection.py
@@ -29,6 +29,18 @@ ASPECT_TYPES: List[Aspect] = [
 ]
 
 
+def verb(aspect: Aspect) -> str:
+    """Return the verb form for a given aspect."""
+    mapping = {
+        Aspect.CONJUNCTION: "conjoins",
+        Aspect.SEXTILE: "sextiles",
+        Aspect.SQUARE: "squares",
+        Aspect.TRINE: "trines",
+        Aspect.OPPOSITION: "opposes",
+    }
+    return mapping.get(aspect, f"{aspect.display_name.lower()}s")
+
+
 def check_future_prohibitions(
     chart: HoraryChart,
     sig1: Planet,
@@ -199,7 +211,7 @@ def check_future_prohibitions(
                                         "prohibitor": planet,
                                         "significator": sig1,
                                         "t_prohibition": t1,
-                                        "reason": f"{planet.value} {aspect.display_name.lower()}s {sig1.value} before perfection",
+                                        "reason": f"{planet.value} {verb(aspect)} {sig1.value} before perfection",
                                     },
                                 }
                             )
@@ -213,7 +225,7 @@ def check_future_prohibitions(
                                         "prohibitor": planet,
                                         "significator": sig2,
                                         "t_prohibition": t2,
-                                        "reason": f"{planet.value} {aspect.display_name.lower()}s {sig2.value} before perfection",
+                                        "reason": f"{planet.value} {verb(aspect)} {sig2.value} before perfection",
                                     },
                                 }
                             )
@@ -227,7 +239,7 @@ def check_future_prohibitions(
                             "prohibitor": planet,
                             "significator": sig1,
                             "t_prohibition": t1,
-                            "reason": f"{planet.value} {aspect.display_name.lower()}s {sig1.value} before perfection",
+                            "reason": f"{planet.value} {verb(aspect)} {sig1.value} before perfection",
                         },
                     }
                 )
@@ -241,7 +253,7 @@ def check_future_prohibitions(
                             "prohibitor": planet,
                             "significator": sig2,
                             "t_prohibition": t2,
-                            "reason": f"{planet.value} {aspect.display_name.lower()}s {sig2.value} before perfection",
+                            "reason": f"{planet.value} {verb(aspect)} {sig2.value} before perfection",
                         },
                     }
                 )


### PR DESCRIPTION
## Summary
- add `verb` helper to map aspect types to verbs
- use `verb` helper in prohibition reasoning

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac0c0bb488832498595f39e586b2bf